### PR TITLE
Add feature to bypass Content Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Both HTTP and HTTPS are supported.
    * [Data usage](#data-usage)
    * [Userscript compatibility](#userscript-compatibility)
    * [Options](#options)
+      * [--bypass-csp ALLOW](#--bypass-csp-allow)
       * [--inline, -i](#--inline--i)
       * [--list-injected, -l](#--list-injected--l)
       * [--no-default-rules](#--no-default-rules)
@@ -35,7 +36,7 @@ Both HTTP and HTTPS are supported.
       * [--userscripts-dir DIR, -u DIR](#--userscripts-dir-dir--u-dir)
    * [Contribute](#contribute)
 
-<!-- Added by: alling, at: sön 12 apr 2020 19:56:29 CEST -->
+<!-- Added by: alling, at: sön 21 mar 2021 20:35:05 CET -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ docker run -t --rm --name userscript-proxy -p 8080:8080 alling/userscript-proxy 
 #          flags to `docker run`                                                flags to Userscript Proxy
 ```
 
+## `--bypass-csp ALLOW`
+
+Bypass host site's Content Security Policy (if any) to allow userscripts to run properly.
+If `ALLOW` is `script`, the CSP is bypassed only for the userscript itself.
+Use `nothing` to never bypass any CSP (meaning userscripts won't work at all on some sites).
+Use `everything` to allow everything, which may be necessary if the userscript injects CSS, images etc.
+Note that the latter completely disables any CSP from every host site into which a userscript is injected.
+Defaults to `script`.
+
 ## `--inline`, `-i`
 
 Always inject scripts inline (`<script>...</script>`), never linked (`<script src="..."></script>`).

--- a/src/injector.py
+++ b/src/injector.py
@@ -187,7 +187,8 @@ class UserscriptInjector:
                             logError(unsafeSequencesMessage(script))
                             continue
                         logInfo(f"""Injecting {script.name}{"" if script.version is None else " " + C.VERSION_PREFIX + script.version} into {requestURL} ({"inline" if useInline else "linked"}) ...""")
-                        nonce = csp.generateNonce()
+                        shouldUseNonce = useInline and option(A.bypass_csp) == A.bypass_csp_script # If not inline, then URL is used for bypassing; if bypass for nothing or everything, then the nonce would have no effect anyway.
+                        nonce = csp.generateNonce() if shouldUseNonce else None
                         result = inject.inject(script, soup, inject.Options(
                             inline = option(A.inline),
                             nonce = nonce
@@ -196,7 +197,6 @@ class UserscriptInjector:
                             soup = result
                             injections.append(csp.Injection(
                                 userscript = script,
-                                useInline = useInline,
                                 nonce = nonce,
                             ))
                         else:

--- a/src/injector.py
+++ b/src/injector.py
@@ -140,7 +140,7 @@ class UserscriptInjector:
         loader.add_option(sanitize(A.inline), bool, False, A.inline_help)
         loader.add_option(sanitize(A.no_default_userscripts), bool, False, A.no_default_userscripts_help)
         loader.add_option(sanitize(A.list_injected), bool, False, A.list_injected_help)
-        loader.add_option(sanitize(A.bypass_csp), Optional[str], None, A.bypass_csp_help)
+        loader.add_option(sanitize(A.bypass_csp), Optional[str], A.bypass_csp_default, A.bypass_csp_help)
         loader.add_option(sanitize(A.userscripts_dir), Optional[str], A.userscripts_dir_default, A.userscripts_dir_help)
         loader.add_option(sanitize(A.query_param_to_disable), str, A.query_param_to_disable_default, A.query_param_to_disable_help)
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -55,6 +55,7 @@ try:
     useTransparent = args.transparent
     useFiltering = useCustomFiltering or useDefaultRules
     useIntercept = args.intercept is True
+    bypassCsp = args.bypass_csp
     userscriptsDirectory = args.userscripts_dir
     checkThatUserscriptsDirectoryExistsIfSpecified(userscriptsDirectory)
     def ruleFilesContent_default():
@@ -101,6 +102,7 @@ try:
         "--set", f"""{sanitize(A.inline)}={str(args.inline).lower()}""",
         "--set", f"""{sanitize(A.list_injected)}={str(args.list_injected).lower()}""",
         "--set", f"""{sanitize(A.no_default_userscripts)}={str(args.no_default_userscripts).lower()}""",
+        "--set", "" if bypassCsp is None else f"""{sanitize(A.bypass_csp)}={bypassCsp}""",
         "--set", "" if userscriptsDirectory is None else f"""{sanitize(A.userscripts_dir)}={userscriptsDirectory}""",
         "--set", f"""{sanitize(A.query_param_to_disable)}={args.query_param_to_disable}""",
         # Empty string breaks the argument chain:

--- a/src/modules/argparser.py
+++ b/src/modules/argparser.py
@@ -7,6 +7,14 @@ from modules.utilities import flag, shortFlag
 def getArgparser():
     argparser = ArgumentParser(description=T.description)
     argparser.add_argument(
+        flag(A.bypass_csp),
+        type=str,
+        metavar=A.metavar_allow,
+        choices=A.bypass_csp_values,
+        default=A.bypass_csp_default,
+        help=A.bypass_csp_help,
+    )
+    argparser.add_argument(
         flag(A.intercept),
         action="store_true",
         help=A.intercept_help,

--- a/src/modules/arguments.py
+++ b/src/modules/arguments.py
@@ -4,8 +4,17 @@ from modules.utilities import flag
 metavar_file = "FILE"
 metavar_dir = "DIR"
 metavar_param = "PARAM"
+metavar_allow = "ALLOW"
 
 RULES = "rules"
+
+bypass_csp = "bypass-csp"
+bypass_csp_never = "never"
+bypass_csp_script = "script"
+bypass_csp_everything = "everything"
+bypass_csp_default = bypass_csp_never
+bypass_csp_values = { bypass_csp_never, bypass_csp_script, bypass_csp_everything }
+bypass_csp_help = f"Bypass host site's Content Security Policy to allow userscripts to run properly. If {metavar_allow} is '{bypass_csp_script}', the CSP is bypassed only for the userscript itself. Use '{bypass_csp_everything}' to allow everything, which may be necessary if the userscript injects CSS, images etc. Note that the latter completely disables any CSP from every host site into which a userscript is injected. Default: '{bypass_csp_default}'."
 
 inline = "inline"
 inline_short = "i"

--- a/src/modules/arguments.py
+++ b/src/modules/arguments.py
@@ -9,11 +9,11 @@ metavar_allow = "ALLOW"
 RULES = "rules"
 
 bypass_csp = "bypass-csp"
-bypass_csp_never = "never"
+bypass_csp_nothing = "nothing"
 bypass_csp_script = "script"
 bypass_csp_everything = "everything"
-bypass_csp_default = bypass_csp_never
-bypass_csp_values = { bypass_csp_never, bypass_csp_script, bypass_csp_everything }
+bypass_csp_default = bypass_csp_nothing
+bypass_csp_values = { bypass_csp_nothing, bypass_csp_script, bypass_csp_everything }
 bypass_csp_help = f"Bypass host site's Content Security Policy to allow userscripts to run properly. If {metavar_allow} is '{bypass_csp_script}', the CSP is bypassed only for the userscript itself. Use '{bypass_csp_everything}' to allow everything, which may be necessary if the userscript injects CSS, images etc. Note that the latter completely disables any CSP from every host site into which a userscript is injected. Default: '{bypass_csp_default}'."
 
 inline = "inline"

--- a/src/modules/arguments.py
+++ b/src/modules/arguments.py
@@ -12,7 +12,7 @@ bypass_csp = "bypass-csp"
 bypass_csp_nothing = "nothing"
 bypass_csp_script = "script"
 bypass_csp_everything = "everything"
-bypass_csp_default = bypass_csp_nothing
+bypass_csp_default = bypass_csp_script
 bypass_csp_values = { bypass_csp_nothing, bypass_csp_script, bypass_csp_everything }
 bypass_csp_help = f"Bypass host site's Content Security Policy to allow userscripts to run properly. If {metavar_allow} is '{bypass_csp_script}', the CSP is bypassed only for the userscript itself. Use '{bypass_csp_everything}' to allow everything, which may be necessary if the userscript injects CSS, images etc. Note that the latter completely disables any CSP from every host site into which a userscript is injected. Default: '{bypass_csp_default}'."
 

--- a/src/modules/csp.py
+++ b/src/modules/csp.py
@@ -1,15 +1,15 @@
 import secrets
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 
 from modules.userscript import Userscript
+from modules.utilities import isSomething
 
 # Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 
 class Injection(NamedTuple):
     userscript: Userscript
-    useInline: bool
-    nonce: str
+    nonce: Optional[str]
 
 
 def headerWithScriptsAllowed(cspHeaderValue: str, injections: List[Injection]) -> str:
@@ -29,7 +29,7 @@ def headerWithScriptsAllowed(cspHeaderValue: str, injections: List[Injection]) -
 
 
 def source(injection: Injection) -> str:
-    if injection.useInline:
+    if isSomething(injection.nonce):
         return f"'nonce-{injection.nonce}'"
     else:
         # MDN about host (i.e. download URL) sources: "Unlike other values below, single quotes shouldn't be used."

--- a/src/modules/csp.py
+++ b/src/modules/csp.py
@@ -1,0 +1,40 @@
+import secrets
+from typing import List, NamedTuple
+
+from modules.userscript import Userscript
+
+# Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+
+
+class Injection(NamedTuple):
+    userscript: Userscript
+    useInline: bool
+    nonce: str
+
+
+def headerWithScriptsAllowed(cspHeaderValue: str, injections: List[Injection]) -> str:
+    # Example CSP header:
+    #
+    #     Content-Security-Policy: default-src 'self'; frame-src 'self'; img-src https:; connect-src 'self'
+    #
+    cspKeyValuePairs = [ directive.strip().split(" ", 1) for directive in cspHeaderValue.split(';') ]
+    cspDict = { key: value for key, value in cspKeyValuePairs }
+    if "script-src" not in cspDict:
+        # Browsers fall back to default-src if there is no script-src.
+        # Since there was no script-src directive and we are adding one, we include the default-src (if present) in it to avoid breaking the site's effective CSP.
+        cspDict["script-src"] = cspDict["default-src"] if "default-src" in cspDict else ""
+    sourcesToAllow = [ source(i) for i in injections ]
+    cspDict["script-src"] += " " + " ".join(sourcesToAllow)
+    return '; '.join([ f'{key} {value}' for key, value in cspDict.items() ])
+
+
+def source(injection: Injection) -> str:
+    if injection.useInline:
+        return f"'nonce-{injection.nonce}'"
+    else:
+        # MDN about host (i.e. download URL) sources: "Unlike other values below, single quotes shouldn't be used."
+        return injection.userscript.downloadURL
+
+
+def generateNonce():
+    return secrets.token_hex() # If no argument is passed, "a reasonable default is used" for the number of bytes.

--- a/src/modules/inject.py
+++ b/src/modules/inject.py
@@ -1,21 +1,22 @@
-from typing import NamedTuple, Union
+from typing import NamedTuple, Optional, Union
 
 from bs4 import BeautifulSoup, Tag
 
 import modules.constants as C
 import modules.userscript as userscript
 from modules.userscript import Userscript, document_end, document_idle
-from modules.utilities import fromOptional, idem, stripIndentation
+from modules.utilities import fromOptional, idem, isSomething, stripIndentation
 
 class Options(NamedTuple):
     inline: bool
-    nonce: str
+    nonce: Optional[str]
 
 
 def inject(script: Userscript, soup: BeautifulSoup, options: Options) -> Union[BeautifulSoup, Exception]:
     useInline = options.inline or script.downloadURL is None
     tag = soup.new_tag("script")
-    tag["nonce"] = options.nonce # Used to bypass CSP for inline-injected userscripts.
+    if isSomething(options.nonce):
+        tag["nonce"] = options.nonce # Used to bypass CSP for inline-injected userscripts.
     tag[C.ATTRIBUTE_UP_VERSION] = C.VERSION
     withLoadListenerIfRunAtIdle = userscript.withEventListener("load") if script.runAt == document_idle else idem
     withNoframesIfNoframes = userscript.withNoframes if script.noframes else idem

--- a/src/modules/inject.py
+++ b/src/modules/inject.py
@@ -9,11 +9,13 @@ from modules.utilities import fromOptional, idem, stripIndentation
 
 class Options(NamedTuple):
     inline: bool
+    nonce: str
 
 
 def inject(script: Userscript, soup: BeautifulSoup, options: Options) -> Union[BeautifulSoup, Exception]:
     useInline = options.inline or script.downloadURL is None
     tag = soup.new_tag("script")
+    tag["nonce"] = options.nonce # Used to bypass CSP for inline-injected userscripts.
     tag[C.ATTRIBUTE_UP_VERSION] = C.VERSION
     withLoadListenerIfRunAtIdle = userscript.withEventListener("load") if script.runAt == document_idle else idem
     withNoframesIfNoframes = userscript.withNoframes if script.noframes else idem


### PR DESCRIPTION
As pointed out by @deatondg in #6, some sites have a CSP that prevents
userscripts from running properly. This PR makes it possible to either
bypass the CSP specifically for any userscripts that are injected
(inline or not) or disable the CSP altogether whenever a userscript is
injected. The latter is often necessary because userscripts tend to
inject at least one resource into the page, be it an external image or
just some inline CSS.

Resolves #6.

Co-authored-by: deatondg <deaton.dg@gmail.com>